### PR TITLE
Find original ship with subtender, take 2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "description": "Plugin.Description",
     "icon": "fa/pie-chart",
     "priority": 100
+  },
+  "dependencies": {
+    "subtender": "0.15.1"
   }
 }

--- a/src/subtender.d.ts
+++ b/src/subtender.d.ts
@@ -1,5 +1,5 @@
-declare module 'subtender/poi' {
-  export function shipRemodelInfoSelector(_: any): {
+declare module 'subtender/tier1' {
+  export function shipRemodelInfoBuilder(_: any): {
     originMstIdOf: { [_: number]: number }
     remodelChains: number[]
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { readJsonSync } from 'fs-extra'
 import fetch from 'node-fetch'
 import { resolve } from 'path'
 import _ from 'lodash'
-// import { shipRemodelInfoSelector } from 'subtender/poi'
+import { shipRemodelInfoBuilder } from 'subtender/tier1'
 
 const { name, version } = readJsonSync(resolve(__dirname, '../package.json'))
 
@@ -64,51 +64,20 @@ const losC2: { [_: number]: number } = {
 export const getEquipmentF33 = (master: any, equip: any): number =>
   (master.api_saku + (losC1[master.api_type[2]] || 0) * Math.sqrt(equip.api_level || 0)) * (losC2[master.api_type[2]] || 0.6)
 
-const getActualPrevId = (es: { api_id: number }[], forId: string): number | null =>
-  es.length === 1 ? es[0].api_id : (es.find(e => +(window as any).$ships[forId].api_aftershipid !== e.api_id) || {}).api_id || null
-
-const getPrevIds = (): { [_: number]: number | null } =>
-  _((window as any).$ships)
-    .filter(e => +e.api_aftershipid)
-    .groupBy('api_aftershipid')
-    .mapValues((es, forId) => getActualPrevId(es, forId))
-    .value()
-
-const getBaseId = (shipId: number, prevIds: { [_: number]: number | null }, useSort: boolean = false): number => {
-  for (let i = 0, id = shipId; i < 10; ++i) {
-    const prev = prevIds[id]
-    if (!prev || (useSort && (window as any).$ships[id].api_sort_id % 10 === 1)) {
-      return id
-    }
-    id = prev
-  }
-  if (useSort) {
-    console.warn(name, 'getBaseId', `can't find base id for ${shipId}`)
-  }
-  return useSort ? shipId : getBaseId(shipId, prevIds, true)
-}
-
 export const getShipCounts = (): { [_: number]: number } => {
-  const prevIds = getPrevIds()
+  const { $ships } = window as any
+  const { originMstIdOf } = shipRemodelInfoBuilder($ships)
+
+  const getBaseId = (shipId: number): number => {
+    const base = originMstIdOf[shipId]
+    if (!base) {
+      console.warn(name, 'getBaseId', `can't find base id for ${shipId}`)
+      return shipId
+    }
+    return base
+  }
+
   return _((window as any)._ships)
-    .countBy(e => getBaseId(e.api_ship_id, prevIds))
+    .countBy(e => getBaseId(e.api_ship_id))
     .value()
 }
-
-// export const getShipCounts = (): { [_: number]: number } => {
-//   const poiState = (window as any).getStore()
-//   const { originMstIdOf } = shipRemodelInfoSelector(poiState)
-
-//   const getBaseId = (shipId: number): number => {
-//     const base = originMstIdOf[shipId]
-//     if (!base) {
-//       console.warn(name, 'getBaseId', `can't find base id for ${shipId}`)
-//       return shipId
-//     }
-//     return base
-//   }
-
-//   return _((window as any)._ships)
-//     .countBy(e => getBaseId(e.api_ship_id))
-//     .value()
-// }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,12 +64,23 @@ const losC2: { [_: number]: number } = {
 export const getEquipmentF33 = (master: any, equip: any): number =>
   (master.api_saku + (losC1[master.api_type[2]] || 0) * Math.sqrt(equip.api_level || 0)) * (losC2[master.api_type[2]] || 0.6)
 
+// Since figuring out remodels involves traversing through non-abyssal elements in $ships,
+// it's desirable to have this value cached.
+// originMstIdOf only needs to be re-computed if window.$ships changes,
+// here we can perform a simple check on $ships' referential equality.
+let $shipsSrc: object | undefined = undefined
+let originMstIdOf: { [_: number]: number } | undefined = undefined
+
 export const getShipCounts = (): { [_: number]: number } => {
   const { $ships } = window as any
-  const { originMstIdOf } = shipRemodelInfoBuilder($ships)
+
+  if ($ships !== $shipsSrc || !originMstIdOf) {
+    $shipsSrc = $ships
+    originMstIdOf = shipRemodelInfoBuilder($ships).originMstIdOf
+  }
 
   const getBaseId = (shipId: number): number => {
-    const base = originMstIdOf[shipId]
+    const base = originMstIdOf![shipId]
     if (!base) {
       console.warn(name, 'getBaseId', `can't find base id for ${shipId}`)
       return shipId

--- a/test/subtender.d.ts
+++ b/test/subtender.d.ts
@@ -1,5 +1,5 @@
-declare module 'subtender/poi' {
-  export function shipRemodelInfoSelector(_: any): {
+declare module 'subtender/tier1' {
+  export function shipRemodelInfoBuilder(_: any): {
     originMstIdOf: { [_: number]: number }
     remodelChains: number[]
   }


### PR DESCRIPTION
This fixes a bunch of `poi-plugin-tsundb getBaseId can't find base id for ...` warnings, mainly for Souya.

Algorithm is simplified a bit by groupping on `api_yomi` instead. In addition this no longer depends on some infra provided by poi - `yarn test` should now be passing.